### PR TITLE
fix notify-py requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 wafw00f
 urllib3
-notifypy
+notify-py
 pync


### PR DESCRIPTION
Fixing `notify` lib requirement

```diff
-notifypy
+notify-py
``` 