### PR TITLE
Added Transfer_encoding methods

### DIFF
--- a/modules/transfer_encodings.py
+++ b/modules/transfer_encodings.py
@@ -1,0 +1,46 @@
+import requests
+
+
+def check_response(url, transfer_encodings=None):
+    try:
+        headers = {}
+
+        # Add Transfer-Encoding to headers if specified
+        if transfer_encodings:
+            headers["Transfer-Encoding"] = ", ".join(transfer_encodings)
+
+        response = requests.get(url, headers=headers, timeout=10)
+
+        transfer_encoding = response.headers.get("Transfer-Encoding")
+        content_encoding = response.headers.get("Content-Encoding")
+
+        print(f"Checking URL: {url}")
+
+        if transfer_encoding:
+            print(f"Transfer-Encoding: {transfer_encoding}")
+            if "chunked" in transfer_encoding.lower():
+                print("Response uses chunked transfer encoding.")
+            else:
+                print("Response does not use chunked transfer encoding.")
+        else:
+            print("No Transfer-Encoding found.")
+
+        if content_encoding:
+            print(f"Content-Encoding: {content_encoding}")
+            if "gzip" in content_encoding.lower():
+                print("Response content is gzipped.")
+            if "deflate" in content_encoding.lower():
+                print("Response content is deflated.")
+            if "compress" in content_encoding.lower():
+                print("Response content is compressed.")
+        else:
+            print("No Content-Encoding found.")
+
+    except requests.exceptions.Timeout:
+        print("Error: Request timed out.")
+    except requests.exceptions.ConnectionError:
+        print("Error: Connection failed.")
+    except requests.exceptions.HTTPError as e:
+        print(f"HTTP error occurred: {e}")
+    except requests.exceptions.RequestException as e:
+        print(f"Error checking URL: {e}")


### PR DESCRIPTION
Hello there ,

In this PR I have added code for **transfer-encoding** method to work. 

It work's with    `-te for arguments` .

```
python3 hexhttp.py -u https://evil.com -te chunked
python3 hexhttp.py -u https://evil.com -te gzip
python3 hexhttp.py -u https://evil.com -te compress

 ```



Output look's like this: 
![te](https://github.com/user-attachments/assets/a5e8e5d0-7efd-4255-82a1-2b7093a0bb79)


I am looking help to adjust code such that `python3 hexhttp.py -u https://evil.com -te `  when `-te`  is used it should check for all method's i.e. `chunked , gzip,compress, deflate`
