### PR TITLE
refactor(errors): normalized how errors were caught in cpdos modules

### DIFF
--- a/modules/CPDoS.py
+++ b/modules/CPDoS.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from modules.utils import *
+from modules.utils import random, re, sys, configure_logger
 from modules.cpdos.cache_error import get_error
 from modules.cpdos.waf_rules import waf_rules
 from modules.cpdos.hho import HHO
@@ -10,11 +10,13 @@ from modules.cpdos.hmo import HMO
 from modules.cpdos.hhcn import HHCN
 from modules.cpdos.hbh import HBH
 
+logger = configure_logger(__name__)
+
+
 def crawl_files(url, s, req_main, domain, custom_header, authent):
     try:
         regexp1 = r'(?<=src=")(\/[^\/].+?\.(js|css))(?=")'
         regexp2 = r'(?<=href=")(\/[^\/].+?\.(js|css))(?=")'
-
 
         responseText = req_main.text
 
@@ -26,25 +28,32 @@ def crawl_files(url, s, req_main, domain, custom_header, authent):
                 if len(url.split("/")) > 4:
                     url = f"{'/'.join(url.split('/')[:3])}/"
                 uri = f"{url}{fu[0]}"
-                if uri.startswith('https://'):
+                if uri.startswith("https://"):
                     uri = f"https://{uri[8:].replace('//', '/')}"
-                elif uri.startswith('http://'):
+                elif uri.startswith("http://"):
                     uri = f"https://{uri[7:].replace('//', '/')}"
 
-                #print(uri)
+                # print(uri)
                 run_cpdos_modules(uri, s, req_main, domain, custom_header, authent)
-    except:
-        #traceback.print_exc()
-        pass
-
+    except Exception as e:
+        logger.exception(e)
 
 
 def run_cpdos_modules(url, s, req_main, domain, custom_header, authent):
-    uri = "{}?CPDoS={}".format(url, random.randint(1, 100), random.randint(1, 100))
-    headers = {'User-agent': 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; LCJB; rv:11.0) like Gecko'}
+    uri = f"{url}?CPDoS={random.randint(1, 100)}"
+    headers = {
+        "User-agent": "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; LCJB; rv:11.0) like Gecko"
+    }
     try:
-        req_main = s.get(url, headers=headers, verify=False, allow_redirects=False, timeout=15, auth=authent)
-        #print(req_main.content)
+        req_main = s.get(
+            url,
+            headers=headers,
+            verify=False,
+            allow_redirects=False,
+            timeout=15,
+            auth=authent,
+        )
+        logger.debug(req_main.content)
 
         main_len = len(req_main.content)
         main_status_code = req_main.status_code
@@ -52,24 +61,25 @@ def run_cpdos_modules(url, s, req_main, domain, custom_header, authent):
         HHO(uri, s, main_status_code, authent)
         HMC(uri, s, main_status_code, authent)
         HMO(uri, s, req_main, authent)
-        HHCN(uri, s, authent)
+        HHCN(uri, s, req_main, authent)
         HBH(url, s, req_main, authent)
         get_error(uri, s, main_status_code, main_len, authent)
-        #waf_rules(url, s, main_status_code, authent)
+        # waf_rules(url, s, main_status_code, authent)
     except KeyboardInterrupt:
         print(" ! Canceled by keyboard interrupt (Ctrl-C)")
-        sys.exit() 
-    except:
-        #traceback.print_exc()
-        pass
+        sys.exit()
+    except Exception as e:
+        logger.exception(e)
+
 
 def check_CPDoS(url, s, req_main, domain, custom_header, authent):
-    i = 0
-    redirect_req = False
-
     if req_main.status_code in [301, 302]:
-        url = req_main.headers['location'] if "http" in req_main.headers['location'] else "{}{}".format(url, req_main.headers['location'])
-        
+        url = (
+            req_main.headers["location"]
+            if "http" in req_main.headers["location"]
+            else f'{url}{req_main.headers["location"]}'
+        )
+
     print("\033[36m ├ CPDoS analyse\033[0m")
 
     run_cpdos_modules(url, s, req_main, domain, custom_header, authent)

--- a/modules/cpdos/hbh.py
+++ b/modules/cpdos/hbh.py
@@ -6,9 +6,9 @@ Attempts to find Hop-By-Hop Header abuse
 https://nathandavison.com/blog/abusing-http-hop-by-hop-request-headers
 """
 
-from modules.utils import logging, requests, generate_cache_buster
+from modules.utils import requests, generate_cache_buster, configure_logger
 
-logger = logging.getLogger(__name__)
+logger = configure_logger(__name__)
 
 VULN_NAME = "Hop-By-Hop"
 
@@ -22,18 +22,14 @@ def cache_poisoning(
 ):
     """Function to test for cache poisoning"""
 
-    try:
-        response_3 = s.get(
-            url,
-            params=parameters,
-            auth=authentication,
-            allow_redirects=False,
-            verify=False,
-            timeout=10,
-        )
-    except requests.exceptions.ConnectionError as e:
-        pass
-        #nlogger.exception(e)
+    response_3 = s.get(
+        url,
+        params=parameters,
+        auth=authentication,
+        allow_redirects=False,
+        verify=False,
+        timeout=10,
+    )
 
     reason = ""
     if (
@@ -94,8 +90,8 @@ def HBH(
                     verify=False,
                     timeout=10,
                 )
-                # print(f"return: {response_2}") #DEBUG
-                # print(response_2_stat) #DEBUG
+                logger.debug("return: %s", response_2) #DEBUG
+                logger.debug(response_2_previous_status) #DEBUG
 
                 if response_2.status_code not in (
                     response_2_previous_status,
@@ -106,7 +102,7 @@ def HBH(
                 else:
                     response_2_count_status_code += 1
 
-                # print(response_2_count_status_code)
+                logger.debug(response_2_count_status_code)
 
                 if (
                     len(response_2.content) != response_2_previous_size
@@ -148,12 +144,7 @@ def HBH(
                     )
 
             except requests.exceptions.ConnectionError as e:
-                pass
-                #logger.exception(e)
-
-            except Exception as e:
-                pass
-                #logger.exception(e)
+                logger.exception(e)
 
             print(f" \033[34m {headers}\033[0m\r", end="")
             print("\033[K", end="")

--- a/modules/cpdos/hmo.py
+++ b/modules/cpdos/hmo.py
@@ -6,9 +6,9 @@ Attempts to find Cache Poisoning with HTTP Method Override (HMO)
 https://cpdos.org/#HMO
 """
 
-from modules.utils import requests, random, logging
+from modules.utils import requests, random, configure_logger
 
-logger = logging.getLogger(__name__)
+logger = configure_logger(__name__)
 
 VULN_NAME = "HTTP Method Override"
 
@@ -85,8 +85,4 @@ def HMO(url, s, initial_response, authent):
             print("\033[K", end="")
 
         except requests.exceptions.ConnectionError as e:
-            #logger.exception(e)
-            pass
-        except Exception as e:
-            #logger.exception(e)
-            pass
+            logger.exception(e)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -8,6 +8,7 @@ import logging
 import random
 import sys
 import urllib3
+
 # import os
 import traceback
 import pprint
@@ -18,19 +19,38 @@ import requests
 # Local imports
 from static.vuln_notify import vuln_found_notify
 
+# """configuring overal how the loggin is done"""
+# logging.basicConfig(
+#     filename=strftime("./logs/%Y%m%d_%H%M.log"),
+#     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+# )
+
 # To remove HTTPS warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+
 def generate_cache_buster(length: Optional[int] = 12) -> str:
-    """ Generate a random string used as a cache buster """
+    """Generate a random string used as a cache buster"""
 
     if not isinstance(length, int) or length <= 0:
         raise ValueError("[!] Lenght of cacheBuster be a positive integer")
-    return ''.join(random.choice(string.ascii_lowercase) for i in range(length))
+    return "".join(random.choice(string.ascii_lowercase) for i in range(length))
+
+
+def configure_logger(
+    module_name: str, handler: logging.Handler = logging.NullHandler()
+) -> logging.Logger:
+    """Provides a logger instance set to the module provided with a default handler"""
+
+    logger = logging.getLogger(module_name)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
 
 class Colors:
-    """ Colors constants for the output messages """
-    
+    """Colors constants for the output messages"""
+
     RED = "\033[31m"
     YELLOW = "\033[33m"
     GREEN = "\033[32m"


### PR DESCRIPTION
- logging module is set to a nullhandler for now
- commented section for basicConfig to set logging to filename
- HHCN has been added in its linted version
- decided to catch ConnectionError and let the rest bubble up
- HMC wasn't having try except mechanism and any exception was making the program skip all the other modules