### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/modules/cp_cve/CVE202557822.py
+++ b/modules/cp_cve/CVE202557822.py
@@ -80,7 +80,7 @@ def nextjs_ssrf(url: str) -> None:
                             f"{Colors.BLUE}{url}{Colors.RESET} | "
                             f"Can access cloud metadata"
                         )
-                except:
+                except Exception:
                     pass
                     
         except requests.Timeout:

--- a/modules/technos/cloudflare.py
+++ b/modules/technos/cloudflare.py
@@ -48,6 +48,6 @@ def cloudflare(url: str, s: requests.Session) -> None:
                 print(
                     f"{Colors.GREEN}   └──{Colors.RESET} Potential redirect loop exploit possible with {Colors.GREEN}{headers}{Colors.RESET} payload"
                 )
-    except:
+    except Exception:
         pass
     cf_access_bypass_test(url, s)


### PR DESCRIPTION
## Summary

Replaces 2 bare `except:` clauses with `except Exception:` in:

- `modules/technos/cloudflare.py` (line 51)
- `modules/cp_cve/CVE202557822.py` (line 83)

## Why

Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, which can:
- Mask Ctrl+C handling during scans
- Hide critical system signals
- Make debugging harder

Using `except Exception:` preserves the same error handling behavior while respecting system-level exceptions.