### PR TITLE
fix(packaging): expose hexhttp command when installed via pipx/pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,11 @@ test = [
 ]
 
 # setuptools package discovery
+[tool.setuptools]
+py-modules = ["hexhttp", "cli"]
+
 [tool.setuptools.packages.find]
-where = ["."]
-exclude = ["tests*", "docs*"]
+include = ["modules*", "utils*", "static*"]
 
 # Include package data
 [tool.setuptools.package-data]


### PR DESCRIPTION
hexhttp.py and cli.py are top-level modules and were not included in the wheel by setuptools.packages.find, so the hexhttp console entry point failed at runtime with ModuleNotFoundError.

Declare them via py-modules and switch packages.find to an include allowlist so the wheel ships exactly modules, utils and static.